### PR TITLE
Initial work on COSESign builders + COSE enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 base64-url = "1.4.8"
+byteorder = "1.4.3"
 cbor_event = "2.1.3"
 cryptoxide = "0.2.0"
 #curve25519-dalek = { "path" = "curve25519-dalek" }
 linked-hash-map = "0.5.3"
+hex = "0.4.0"
+pruefung = "0.2.1"
 
 # non-wasm
 [target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+base64-url = "1.4.8"
 cbor_event = "2.1.3"
+cryptoxide = "0.2.0"
+#curve25519-dalek = { "path" = "curve25519-dalek" }
 linked-hash-map = "0.5.3"
 
 # non-wasm

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,0 +1,260 @@
+use super::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct COSESign1Builder {
+    headers: Headers,
+    payload: Vec<u8>,
+    external_aad: Option<Vec<u8>>,
+    is_payload_external: bool,
+    hashed: bool,
+}
+
+#[wasm_bindgen]
+impl COSESign1Builder {
+    pub fn new(headers: &Headers, payload: Vec<u8>, is_payload_external: bool) -> Self {
+        Self {
+            headers: headers.clone(),
+            payload,
+            external_aad: None,
+            is_payload_external,
+            hashed: false,
+        }
+    }
+
+    pub fn hash_payload<'a>(&'a mut self) -> &'a mut Self {
+        if self.hashed {
+            self.hashed = true;
+            self.payload = crypto::blake2b224(self.payload.as_ref()).to_vec();
+        }
+        self
+    }
+
+    pub fn set_external_aad<'a>(&'a mut self, external_aad: Vec<u8>) -> &'a mut Self {
+        self.external_aad = Some(external_aad);
+        self
+    }
+
+    pub fn make_data_to_sign(&self) -> SigStructure {
+        SigStructure::new(
+            SigContext::Signature1,
+            &self.headers.protected,
+            self.external_aad.clone().unwrap_or(vec![]),
+            self.payload.clone())
+    }
+
+    pub fn build(&self, signed_sig_structure: Vec<u8>) -> COSESign1 {
+        COSESign1::new(
+            &self.headers,
+            match self.is_payload_external {
+                true => None,
+                false => Some(self.payload.clone())
+            },
+            signed_sig_structure
+        )
+    }
+}
+
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct COSESignBuilder {
+    headers: Headers,
+    payload: Vec<u8>,
+    external_aad: Option<Vec<u8>>,
+    is_payload_external: bool,
+    hashed: bool,
+}
+
+#[wasm_bindgen]
+impl COSESignBuilder {
+    pub fn new(headers: &Headers, payload: Vec<u8>, is_payload_external: bool) -> Self {
+        Self {
+            headers: headers.clone(),
+            payload,
+            external_aad: None,
+            is_payload_external,
+            hashed: false,
+        }
+    }
+
+    pub fn hash_payload<'a>(&'a mut self) -> &'a mut Self {
+        if self.hashed {
+            self.hashed = true;
+            self.payload = crypto::blake2b224(self.payload.as_ref()).to_vec();
+        }
+        self
+    }
+
+    pub fn set_external_aad<'a>(&'a mut self, external_aad: Vec<u8>) -> &'a mut Self {
+        self.external_aad = Some(external_aad);
+        self
+    }
+
+    pub fn make_data_to_sign(&self) -> SigStructure {
+        SigStructure::new(
+            SigContext::Signature,
+            &self.headers.protected,
+            self.external_aad.clone().unwrap_or(vec![]),
+            self.payload.clone())
+    }
+
+    pub fn build(&self, signed_sig_structure: &COSESignatures) -> COSESign {
+        COSESign::new(
+            &self.headers,
+            match self.is_payload_external {
+                true => None,
+                false => Some(self.payload.clone())
+            },
+            signed_sig_structure)
+    }
+}
+
+// TODO: copy the COSESign(1) builders for COSEEncrypt(1) if this seems like a good approach
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub enum AlgorithmIds {
+    // EdDSA (Pure EdDSA, not HashedEdDSA) - the algorithm used for Cardano addresses
+    EdDSA = -8,
+    // ChaCha20/Poly1305 w/ 256-bit key, 128-bit tag
+    ChaCha20Poly1305 = 24,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub enum KeyTypes {
+    // octet key pair
+    OKP = 1,
+    // 2-coord EC
+    EC2 = 2,
+    Symmetric = 4,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub enum ECKeys {
+    // EC identifier
+    CRV = -1,
+    // x coord
+    X = -2,
+    // y coord (only for EC2 - not present in OKP)
+    Y = -3,
+    // private key (optional)
+    D = -4,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub enum CurveTypes {
+    P256 = 1,
+    P384 = 2,
+    P521 = 3,
+    X25519 = 4,
+    X448 = 5,
+    // the EdDSA variant used for cardano addresses
+    Ed25519 = 6,
+    Ed448 = 7,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub enum KeyOperations {
+    // The key is used to create signatures. Requires private key fields
+    Sign = 1,
+    // The key is used for verification of signatures.
+    Verify = 2,
+    // The key is used for key transport encryption. 
+    Encrypt = 3,
+    // The key is used for key transport decryption. Requires private key fields.
+    Decrypt = 4,
+    // The key is used for key wrap encryption.
+    WrapKey = 5,
+    // The key is used for key wrap decryption. Requires private key fields.
+    UnwrapKey = 6,
+    // The key is used for deriving keys. Requires private key fields
+    DeriveKey = 7,
+    // The key is used for deriving bits not to be used as a key. Requires private key fields
+    DeriveBits = 8,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct EdDSA25519KeyBuilder {
+    pubkey_bytes: Vec<u8>,
+    prvkey_bytes: Option<Vec<u8>>,
+    for_signing: bool,
+    for_verifying: bool,
+}
+
+#[wasm_bindgen]
+impl EdDSA25519KeyBuilder {
+    pub fn new(pubkey_bytes: Vec<u8>) -> Self {
+        Self {
+            pubkey_bytes,
+            prvkey_bytes: None,
+            for_signing: false,
+            for_verifying: false,
+        }
+    }
+
+    pub fn set_private_key(&mut self, private_key_bytes: Vec<u8>) {
+        self.prvkey_bytes = Some(private_key_bytes);
+    }
+
+    pub fn is_for_signing(&mut self) {
+        self.for_signing = true;
+    }
+
+    pub fn is_for_verifying(&mut self) {
+        self.for_verifying = true;
+    }
+
+    pub fn build(&self) -> COSEKey {
+        let mut key = COSEKey::new(&Label::new_int(&Int::new_i32(KeyTypes::OKP as i32)));
+        // crv
+        key.other_headers.insert(
+            Label::new_int(&Int::new_i32(ECKeys::CRV as i32)),
+            Value::U64(CurveTypes::Ed25519 as u64));
+        // x
+        key.other_headers.insert(
+            Label::new_int(&Int::new_i32(ECKeys::X as i32)),
+            Value::Bytes(self.pubkey_bytes.clone()));
+        // d (privkey)
+        if let Some(d) = &self.prvkey_bytes {
+            key.other_headers.insert(
+                Label::new_int(&Int::new_i32(ECKeys::D as i32)),
+                Value::Bytes(d.clone()));
+        }
+        // alg
+        key.set_algorithm_id(&Label::new_int(&Int::new_i32(AlgorithmIds::EdDSA as i32)));
+        // key-ops
+        if self.for_signing || self.for_verifying {
+            let mut key_ops = Labels::new();
+            if self.for_signing {
+                key_ops.add(&Label::new_int(&Int::new_i32(KeyOperations::Sign as i32)));
+            }
+            if self.for_verifying {
+                key_ops.add(&Label::new_int(&Int::new_i32(KeyOperations::Verify as i32)));
+            }
+            key.set_key_ops(&key_ops);
+        }
+        key
+    }
+}
+
+// TODO: a way to parse/check from COSEKey -> EdDSA25519 variant. Or should this be a wrapper not a builder?
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cose_sign1() {
+        // let mut protected_header = HeaderMap::new();
+        // protected_header.set_algorithm_id(&Label::new_int(&Int::new_i32(x: i32)));
+        // let headers = Headers::new(&protected, &unprotected);
+        // let payload = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        // let mut builder = COSESign1Builder::new(&headers, payload, true);
+    }
+}

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -1,0 +1,648 @@
+use super::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TaggedCBOR {
+    tag: BigNum,
+    value: CBORValue,
+}
+
+#[wasm_bindgen]
+impl TaggedCBOR {
+    pub fn tag(&self) -> BigNum {
+        self.tag
+    }
+
+    pub fn value(&self) -> CBORValue {
+        self.value.clone()
+    }
+
+    pub fn new(tag: BigNum, value: &CBORValue) -> Self {
+        Self {
+            tag,
+            value: value.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CBORArray {
+    definite: bool,
+    pub (crate) values: Vec<CBORValue>,
+}
+
+#[wasm_bindgen]
+impl CBORArray {
+    pub fn new() -> Self {
+        Self {
+            definite: true,
+            values: Vec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn get(&self, index: usize) -> CBORValue {
+        self.values[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &CBORValue) {
+        self.values.push(elem.clone());
+    }
+
+    // CBOR allows either definite or indefinite encoding - specify which to use here.
+    // Default is definite.
+    pub fn set_definite_encoding(&mut self, use_definite: bool) {
+        self.definite = use_definite
+    }
+
+    // True -> Definite CBOR encoding is used (length explicitly written)
+    // False -> Indefinite CBOR encoding used (length implicit - read/write until CBOR Break found)
+    pub fn is_definite(&self) -> bool {
+        self.definite
+    }
+}
+
+impl From<Vec<CBORValue>> for CBORArray {
+    fn from(vec: Vec<CBORValue>) -> Self {
+        Self {
+            definite: true,
+            values: vec,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CBORObject {
+    definite: bool,
+    values: LinkedHashMap<CBORValue, CBORValue>,
+}
+
+#[wasm_bindgen]
+impl CBORObject {
+    pub fn new() -> Self {
+        Self {
+            definite: true,
+            values: LinkedHashMap::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn insert(&mut self, key: &CBORValue, value: &CBORValue) -> Option<CBORValue> {
+        self.values.insert(key.clone(), value.clone())
+    }
+
+    pub fn get(&self, key: &CBORValue) -> Option<CBORValue> {
+        self.values.get(key).map(|v| v.clone())
+    }
+
+    pub fn keys(&self) -> CBORArray {
+        self.values.iter().map(|(k, _v)| k.clone()).collect::<Vec<CBORValue>>().into()
+    }
+
+    // CBOR allows either definite or indefinite encoding - specify which to use here.
+    // Default is definite.
+    pub fn set_definite_encoding(&mut self, use_definite: bool) {
+        self.definite = use_definite
+    }
+
+    // True -> Definite CBOR encoding is used (length explicitly written)
+    // False -> Indefinite CBOR encoding used (length implicit - read/write until CBOR Break found)
+    pub fn is_definite(&self) -> bool {
+        self.definite
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CBORSpecialType {
+    Bool,
+    Float,
+    Unassigned,
+    Break,
+    Undefined,
+    Null,
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+enum CBORSpecialEnum {
+    Bool(bool),
+    Float(f64),
+    Unassigned(u8),
+    Break,
+    Undefined,
+    Null,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct CBORSpecial(CBORSpecialEnum);
+
+#[wasm_bindgen]
+impl CBORSpecial {
+    pub fn new_bool(b: bool) -> Self {
+        Self(CBORSpecialEnum::Bool(b))
+    }
+
+    pub fn new_float(f: f64) -> Self {
+        Self(CBORSpecialEnum::Float(f))
+    }
+
+    pub fn new_unassigned(u: u8) -> Self {
+        Self(CBORSpecialEnum::Unassigned(u))
+    }
+
+    pub fn new_break() -> Self {
+        Self(CBORSpecialEnum::Break)
+    }
+
+    pub fn new_null() -> Self {
+        Self(CBORSpecialEnum::Null)
+    }
+
+    pub fn new_undefined() -> Self {
+        Self(CBORSpecialEnum::Undefined)
+    }
+
+    pub fn kind(&self) -> CBORSpecialType {
+        match &self.0 {
+            CBORSpecialEnum::Bool(_) => CBORSpecialType::Bool,
+            CBORSpecialEnum::Float(_) => CBORSpecialType::Float,
+            CBORSpecialEnum::Unassigned(_) => CBORSpecialType::Unassigned,
+            CBORSpecialEnum::Break => CBORSpecialType::Break,
+            CBORSpecialEnum::Undefined => CBORSpecialType::Undefined,
+            CBORSpecialEnum::Null => CBORSpecialType::Null,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match &self.0 {
+            CBORSpecialEnum::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    pub fn as_float(&self) -> Option<f64> {
+        match &self.0 {
+            CBORSpecialEnum::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    pub fn as_unassigned(&self) -> Option<u8> {
+        match &self.0 {
+            CBORSpecialEnum::Unassigned(u) => Some(*u),
+            _ => None,
+        }
+    }
+}
+
+// Rust does not provide Ord, Hash or Eq implementations for floats due to issues with
+// NaN, etc. We provide them here and compare floats byte-wise just so we can use the
+// CBORSpecial enum containing them (and others transitively) as keys to follow the CBOR spec.
+fn f64_to_bytes(f: f64) -> [u8; std::mem::size_of::<f64>()] {
+    use byteorder::{BigEndian, WriteBytesExt};
+
+    let mut bytes = [0u8; std::mem::size_of::<f64>()];
+    bytes.as_mut().write_f64::<BigEndian>(f).unwrap();
+    bytes
+}
+
+impl PartialEq for CBORSpecial {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (CBORSpecialEnum::Bool(b1), CBORSpecialEnum::Bool(b2)) => *b1 == *b2,
+            (CBORSpecialEnum::Float(f1), CBORSpecialEnum::Float(f2)) => f64_to_bytes(*f1) == f64_to_bytes(*f2),
+            (CBORSpecialEnum::Unassigned(u1), CBORSpecialEnum::Unassigned(u2)) => *u1 == *u2,
+            (CBORSpecialEnum::Break, CBORSpecialEnum::Break) |
+            (CBORSpecialEnum::Undefined, CBORSpecialEnum::Undefined) |
+            (CBORSpecialEnum::Null, CBORSpecialEnum::Null) => true,
+            _mixed_types => false,
+        }
+    }
+}
+
+impl Eq for CBORSpecial {
+}
+
+impl Ord for CBORSpecial {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (&self.0, &other.0) {
+            (CBORSpecialEnum::Bool(b1), CBORSpecialEnum::Bool(b2)) => b1.cmp(b2),
+            (CBORSpecialEnum::Float(f1), CBORSpecialEnum::Float(f2)) => f64_to_bytes(*f1).cmp(&f64_to_bytes(*f2)),
+            (CBORSpecialEnum::Unassigned(u1), CBORSpecialEnum::Unassigned(u2)) => u1.cmp(u2),
+            (CBORSpecialEnum::Break, CBORSpecialEnum::Break) |
+            (CBORSpecialEnum::Undefined, CBORSpecialEnum::Undefined) |
+            (CBORSpecialEnum::Null, CBORSpecialEnum::Null) => std::cmp::Ordering::Equal,
+            _mixed_types => self.kind().cmp(&other.kind()),
+        }
+    }
+}
+
+impl std::hash::Hash for CBORSpecial {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.kind().hash(state);
+        match &self.0 {
+            CBORSpecialEnum::Bool(b) => b.hash(state),
+            CBORSpecialEnum::Float(f) => f64_to_bytes(*f).hash(state),
+            CBORSpecialEnum::Unassigned(u) => u.hash(state),
+            _no_extra_data => (),
+        }
+    }
+}
+
+impl PartialOrd for CBORSpecial {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CBORValueKind {
+    Int,
+    Bytes,
+    Text,
+    Array,
+    Object,
+    TaggedCBOR,
+    Special,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CBORValueEnum {
+    Int(Int),
+    Bytes(Vec<u8>),
+    Text(String),
+    Array(CBORArray),
+    Object(CBORObject),
+    TaggedCBOR(Box<TaggedCBOR>),
+    Special(CBORSpecial),
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CBORValue(pub (crate) CBORValueEnum);
+
+#[wasm_bindgen]
+impl CBORValue {
+    pub fn new_int(int: &Int) -> Self {
+        Self(CBORValueEnum::Int(int.clone()))
+    }
+
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self(CBORValueEnum::Bytes(bytes))
+    }
+
+    pub fn new_text(text: String) -> Self {
+        Self(CBORValueEnum::Text(text))
+    }
+
+    pub fn new_array(arr: &CBORArray) -> Self {
+        Self(CBORValueEnum::Array(arr.clone()))
+    }
+
+    pub fn new_object(obj: &CBORObject) -> Self {
+        Self(CBORValueEnum::Object(obj.clone()))
+    }
+
+    pub fn new_tagged(tagged: &TaggedCBOR) -> Self {
+        Self(CBORValueEnum::TaggedCBOR(Box::new(tagged.clone())))
+    }
+
+    pub fn new_special(special: &CBORSpecial) -> Self {
+        Self(CBORValueEnum::Special(special.clone()))
+    }
+
+    pub fn kind(&self) -> CBORValueKind {
+        match &self.0 {
+            CBORValueEnum::Int(_) => CBORValueKind::Int,
+            CBORValueEnum::Bytes(_) => CBORValueKind::Bytes,
+            CBORValueEnum::Text(_) => CBORValueKind::Text,
+            CBORValueEnum::Array(_) => CBORValueKind::Array,
+            CBORValueEnum::Object(_) => CBORValueKind::Object,
+            CBORValueEnum::TaggedCBOR(_) => CBORValueKind::TaggedCBOR,
+            CBORValueEnum::Special(_) => CBORValueKind::Special,
+        }
+    }
+
+    pub fn as_int(&self) -> Option<Int> {
+        match &self.0 {
+            CBORValueEnum::Int(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Option<Vec<u8>> {
+        match &self.0 {
+            CBORValueEnum::Bytes(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_text(&self) -> Option<String> {
+        match &self.0 {
+            CBORValueEnum::Text(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_array(&self) -> Option<CBORArray> {
+        match &self.0 {
+            CBORValueEnum::Array(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<CBORObject> {
+        match &self.0 {
+            CBORValueEnum::Object(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_tagged(&self) -> Option<TaggedCBOR> {
+        use std::ops::Deref;
+        match &self.0 {
+            CBORValueEnum::TaggedCBOR(x) => Some((*x).deref().clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_special(&self) -> Option<CBORSpecial> {
+        match &self.0 {
+            CBORValueEnum::Special(x) => Some(x.clone()),
+            _ => None,
+        }
+    }
+}
+
+
+// serialization
+
+use std::io::{Seek, SeekFrom};
+
+impl cbor_event::se::Serialize for TaggedCBOR {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.tag.serialize(serializer)?;
+        self.value.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for TaggedCBOR {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let tag = (|| -> Result<_, DeserializeError> {
+                Ok(BigNum::deserialize(raw)?)
+            })().map_err(|e| e.annotate("tag"))?;
+            let value = (|| -> Result<_, DeserializeError> {
+                Ok(CBORValue::deserialize(raw)?)
+            })().map_err(|e| e.annotate("value"))?;
+            match len {
+                cbor_event::Len::Len(_) => (),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(TaggedCBOR {
+                tag,
+                value,
+            })
+        })().map_err(|e| e.annotate("TaggedCBOR"))
+    }
+}
+
+impl cbor_event::se::Serialize for CBORArray {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        if self.definite {
+            serializer.write_array(cbor_event::Len::Len(self.values.len() as u64))?;
+        } else {
+            serializer.write_array(cbor_event::Len::Indefinite)?;
+        }
+        for element in &self.values {
+            element.serialize(serializer)?;
+        }
+        if !self.definite {
+            serializer.write_special(cbor_event::Special::Break)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for CBORArray {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        let definite = (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let definite = len != cbor_event::Len::Indefinite;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == cbor_event::Type::Special {
+                    assert_eq!(raw.special()?, cbor_event::Special::Break);
+                    break;
+                }
+                arr.push(CBORValue::deserialize(raw)?);
+            }
+            Ok(definite)
+        })().map_err(|e| e.annotate("CBORArray"))?;
+        Ok(Self {
+            definite,
+            values: arr,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for CBORObject {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        if self.definite {
+            serializer.write_map(cbor_event::Len::Len(self.values.len() as u64))?;
+        } else {
+            serializer.write_map(cbor_event::Len::Indefinite)?;
+        }
+        for (key, value) in &self.values {
+            key.serialize(serializer)?;
+            value.serialize(serializer)?;
+        }
+        if !self.definite {
+            serializer.write_special(cbor_event::Special::Break)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for CBORObject {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut table = LinkedHashMap::new();
+        let definite = (|| -> Result<_, DeserializeError> {
+            let len = raw.map()?;
+            let definite = len != cbor_event::Len::Indefinite;
+            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == cbor_event::Type::Special {
+                    assert_eq!(raw.special()?, cbor_event::Special::Break);
+                    break;
+                }
+                let key = CBORValue::deserialize(raw)?;
+                let value = CBORValue::deserialize(raw)?;
+                if table.insert(key.clone(), value).is_some() {
+                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                }
+            }
+            Ok(definite)
+        })().map_err(|e| e.annotate("CBORObject"))?;
+        Ok(Self {
+            definite,
+            values: table,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for CBORSpecialEnum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        let special = match self {
+            CBORSpecialEnum::Bool(b) => cbor_event::Special::Bool(*b),
+            CBORSpecialEnum::Float(f) => cbor_event::Special::Float(*f),
+            CBORSpecialEnum::Unassigned(u) => cbor_event::Special::Unassigned(*u),
+            CBORSpecialEnum::Break => cbor_event::Special::Break,
+            CBORSpecialEnum::Undefined => cbor_event::Special::Undefined,
+            CBORSpecialEnum::Null => cbor_event::Special::Null,
+        };
+        serializer.write_special(special)
+    }
+}
+
+impl Deserialize for CBORSpecialEnum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            Ok(match raw.special()? {
+                cbor_event::Special::Bool(b) => CBORSpecialEnum::Bool(b),
+                cbor_event::Special::Float(f) => CBORSpecialEnum::Float(f),
+                cbor_event::Special::Unassigned(u) => CBORSpecialEnum::Unassigned(u),
+                cbor_event::Special::Break => CBORSpecialEnum::Break,
+                cbor_event::Special::Undefined => CBORSpecialEnum::Undefined,
+                cbor_event::Special::Null => CBORSpecialEnum::Null,
+            })
+        })().map_err(|e| e.annotate("CBORSpecialEnum"))
+    }
+}
+
+impl cbor_event::se::Serialize for CBORSpecial {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for CBORSpecial {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(CBORSpecialEnum::deserialize(raw)?))
+    }
+}
+
+impl cbor_event::se::Serialize for CBORValueEnum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            CBORValueEnum::Int(x) => {
+                x.serialize(serializer)
+            },
+            CBORValueEnum::Bytes(x) => {
+                serializer.write_bytes(&x)
+            },
+            CBORValueEnum::Text(x) => {
+                serializer.write_text(&x)
+            },
+            CBORValueEnum::Array(x) => {
+                x.serialize(serializer)
+            },
+            CBORValueEnum::Object(x) => {
+                x.serialize(serializer)
+            },
+            CBORValueEnum::TaggedCBOR(x) => {
+                x.serialize(serializer)
+            },
+            CBORValueEnum::Special(x) => {
+                x.serialize(serializer)
+            },
+        }
+    }
+}
+
+impl Deserialize for CBORValueEnum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Int::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Int(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(raw.bytes()?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Bytes(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(String::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Text(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(CBORArray::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Array(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(CBORObject::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Object(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(TaggedCBOR::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::TaggedCBOR(Box::new(variant))),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(CBORSpecial::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(variant) => return Ok(CBORValueEnum::Special(variant)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("CBORValueEnum", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("CBORValueEnum"))
+    }
+}
+
+impl cbor_event::se::Serialize for CBORValue {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for CBORValue {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(CBORValueEnum::deserialize(raw)?))
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -10,11 +10,19 @@
 // }
 
 use cryptoxide::blake2b::Blake2b;
+use pruefung::fnv::fnv32::Fnv32a;
 
 pub (crate) fn blake2b224(data: &[u8]) -> [u8; 28] {
     let mut out = [0; 28];
     Blake2b::blake2b(&mut out, data, &[]);
     out
+}
+
+pub (crate) fn fnv32a(data: &[u8]) -> u32 {
+    use core::hash::Hasher;
+    let mut hasher = Fnv32a::default();
+    hasher.write(data);
+    hasher.finish() as u32
 }
 
 // #[cfg(test)]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,38 @@
+//use curve25519_dalek::FieldElement;
+
+// pub fn get_ed25519_x(xpub: &ed25519_bip32::XPub) -> Option<()> {
+    
+//     // let compressed_y = CompressedEdwardsY::from_slice(&bytes[..]);
+//     // let edwards_point = compressed_y.decompress()?;
+//     // let proj_point = edwards_point.to_projective();
+//     //let Y = FieldElement::from_bytes(bytes);
+//     None
+// }
+
+use cryptoxide::blake2b::Blake2b;
+
+pub (crate) fn blake2b224(data: &[u8]) -> [u8; 28] {
+    let mut out = [0; 28];
+    Blake2b::blake2b(&mut out, data, &[]);
+    out
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     fn x_coord() {
+//         let pub_bytes = [
+//             0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07, 0x3a,
+//             0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68, 0xf7, 0x07, 0x51, 0x1a
+//         ];
+//         let compr_y = curve25519_dalek::edwards::CompressedEdwardsY::from_slice(&pub_bytes[..]);
+//         let x_computed = compr_y.compute_x_as_bytes().unwrap();
+//         let x_expected = base64_url::decode("11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo").unwrap();
+//         println!("pub_bytes = {:?}", pub_bytes);
+//         println!("x_expected = {:?}", x_expected);
+//         println!("x_computed = {:?}", x_computed);
+//         assert_eq!(pub_bytes, x_expected.as_ref());
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,11 +902,11 @@ mod tests {
         ops1.add(&label_int(-130));
         let biv1 = vec![0u8; 128];
 
-        let kty1_value = CBORValue::Text(String::from("key type 1"));
-        let kid1_value = CBORValue::Bytes(kid1.clone());
-        let alg1_value = CBORValue::I64(-10);
-        let ops1_value = CBORValue::Array(vec![CBORValue::Text(String::from("dfdsfds")), CBORValue::I64(-130)]);
-        let biv1_value = CBORValue::Bytes(biv1.clone());
+        let kty1_value = CBORValue::new_text(String::from("key type 1"));
+        let kid1_value = CBORValue::new_bytes(kid1.clone());
+        let alg1_value = CBORValue::new_int(&Int::new_i32(-10));
+        let ops1_value = CBORValue::new_array(&vec![CBORValue::new_text(String::from("dfdsfds")), CBORValue::new_int(&Int::new_i32(-130))].into());
+        let biv1_value = CBORValue::new_bytes(biv1.clone());
 
         let kty2 = label_int(352);
         let kid2 = vec![7u8; 23];
@@ -915,11 +915,11 @@ mod tests {
         ops2.add(&label_str("89583249384"));
         let biv2 = vec![10u8, 0u8, 5u8, 9u8, 50u8, 100u8, 30u8];
 
-        let kty2_value = CBORValue::U64(352);
-        let kid2_value = CBORValue::Bytes(kid2.clone());
-        let alg2_value = CBORValue::Text(String::from("algorithm 2"));
-        let ops2_value = CBORValue::Array(vec![CBORValue::Text(String::from("89583249384"))]);
-        let biv2_value = CBORValue::Bytes(biv2.clone());
+        let kty2_value = CBORValue::new_int(&Int::new_i32(352));
+        let kid2_value = CBORValue::new_bytes(kid2.clone());
+        let alg2_value = CBORValue::new_text(String::from("algorithm 2"));
+        let ops2_value = CBORValue::new_array(&vec![CBORValue::new_text(String::from("89583249384"))].into());
+        let biv2_value = CBORValue::new_bytes(biv2.clone());
         
         let mut ck = COSEKey::new(&kty1);
         ck.set_key_id(kid1.clone());
@@ -948,6 +948,7 @@ mod tests {
 
     #[test]
     fn signed_message_user_facing_encoding() {
+        // round-trip testing
         let mut header_map = HeaderMap::new();
         header_map.set_content_type(&Label::new_int(&Int::new_i32(-1000)));
         let headers = Headers::new(&ProtectedHeaderMap::new_empty(), &header_map);
@@ -955,6 +956,7 @@ mod tests {
         let user_facing_encoding = signed_message.to_user_facing_encoding();
         let from_ufe = SignedMessage::from_user_facing_encoding(&user_facing_encoding).unwrap();
         assert_eq!(from_ufe.to_bytes(), signed_message.to_bytes());
+        // test acceptance of padding or lack thereof in data and/or checksum
         let pad1 = SignedMessage::from_user_facing_encoding("cms_hEChAzkD51gnQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQwECZACyaZmw==").unwrap();
         let pad2 = SignedMessage::from_user_facing_encoding("cms_hEChAzkD51gnQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQwECZA==CyaZmw").unwrap();
         let pad3 = SignedMessage::from_user_facing_encoding("cms_hEChAzkD51gnQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQwECZA==CyaZmw==").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}, Value};
 use cbor_event::Type as CBORType;
 use cbor_event::Special as CBORSpecial;
 
+mod builders;
+mod crypto;
 mod error;
 mod serialization;
 #[macro_use]
@@ -201,6 +203,7 @@ pub struct HeaderMap {
     init_vector: Option<Vec<u8>>,
     partial_init_vector: Option<Vec<u8>>,
     counter_signature: Option<Box<COSESignatureOrArrCOSESignature>>,
+    // TODO: write a proper accessor for this
     pub other_headers: LinkedHashMap<Label, Value>,
 }
 
@@ -642,5 +645,76 @@ to_from_bytes!(PubKeyEncryption);
 impl PubKeyEncryption {
     pub fn new(data: &COSEEncrypt) -> Self {
         Self(data.clone())
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct COSEKey {
+    // key type, See KeyType enum (OKP, ECS, etc)
+    key_type: Label,
+    key_id: Option<Vec<u8>>,
+    // algorithm identifier. See AlgorithmIds enum (EdDSA, ChaChaPoly, etc)
+    algorithm_id: Option<Label>,
+    // opertions that this key is valid for if this field exists
+    key_ops: Option<Labels>,
+    base_init_vector: Option<Vec<u8>>,
+    // TODO: write a proper accessor for this
+    pub other_headers: LinkedHashMap<Label, Value>,
+}
+
+to_from_bytes!(COSEKey);
+
+#[wasm_bindgen]
+impl COSEKey {
+    pub fn set_key_type(&mut self, key_type: &Label) {
+        self.key_type = key_type.clone()
+    }
+
+    pub fn key_type(&self) -> Label {
+        self.key_type.clone()
+    }
+
+    pub fn set_key_id(&mut self, key_id: Vec<u8>) {
+        self.key_id = Some(key_id)
+    }
+
+    pub fn key_id(&self) -> Option<Vec<u8>> {
+        self.key_id.clone()
+    }
+    
+    pub fn set_algorithm_id(&mut self, algorithm_id: &Label) {
+        self.algorithm_id = Some(algorithm_id.clone())
+    }
+
+    pub fn algorithm_id(&self) -> Option<Label> {
+        self.algorithm_id.clone()
+    }
+
+    pub fn set_key_ops(&mut self, key_ops: &Labels) {
+        self.key_ops = Some(key_ops.clone())
+    }
+
+    pub fn key_ops(&self) -> Option<Labels> {
+        self.key_ops.clone()
+    }
+
+    pub fn set_base_init_vector(&mut self, base_init_vector: Vec<u8>) {
+        self.base_init_vector = Some(base_init_vector)
+    }
+
+    pub fn base_init_vector(&self) -> Option<Vec<u8>> {
+        self.base_init_vector.clone()
+    }
+
+    pub fn new(key_type: &Label) -> Self {
+        Self {
+            key_type: key_type.clone(),
+            key_id: None,
+            algorithm_id: None,
+            key_ops: None,
+            base_init_vector: None,
+            other_headers: LinkedHashMap::new(),
+        }
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1017,21 +1017,83 @@ mod tests {
     fn print_cbor_types(vec: &Vec<u8>) {
         use cbor_event::Type;
         let mut raw = Deserializer::from(std::io::Cursor::new(vec));
-        println!("CBOR read = {{");
+        let mut lens = Vec::new();
+        let mut consume_elem = |lens: &mut Vec<cbor_event::Len>| {
+            if let Some(len) = lens.last_mut() {
+                if let cbor_event::Len::Len(n) = len {
+                    *n -= 1;
+                }
+            };
+        };
+        let mut reduce_depth = |lens: &mut Vec<cbor_event::Len>| {
+            while let Some(cbor_event::Len::Len(0)) = lens.last() {
+                lens.pop();
+                println!("{}}}", "\t".repeat(lens.len()));
+            }
+        };
         loop {
+            print!("{}", "\t".repeat(lens.len()));
             match raw.cbor_type() {
                 Err(_) => break,
-                Ok(Type::UnsignedInteger) => println!("UINT({})", raw.unsigned_integer().unwrap()),
-                Ok(Type::NegativeInteger) => println!("NINT({})", raw.negative_integer().unwrap()),
-                Ok(Type::Bytes) => println!("BYTES({:?})", raw.bytes().unwrap()),
-                Ok(Type::Text) => println!("TEXT({})", raw.text().unwrap()),
-                Ok(Type::Array) => println!("ARRAY({:?})", raw.array().unwrap()),
-                Ok(Type::Map) => println!("MAP({:?})", raw.map().unwrap()),
+                Ok(Type::UnsignedInteger) => {
+                    println!("UINT({})", raw.unsigned_integer().unwrap());
+                    consume_elem(&mut lens);
+                    reduce_depth(&mut lens);
+                },
+                Ok(Type::NegativeInteger) => {
+                    println!("NINT({})", raw.negative_integer().unwrap());
+                    consume_elem(&mut lens);
+                    reduce_depth(&mut lens);
+                },
+                Ok(Type::Bytes) => {
+                    println!("BYTES({:?})", raw.bytes().unwrap());
+                    consume_elem(&mut lens);
+                    reduce_depth(&mut lens);
+                },
+                Ok(Type::Text) => {
+                    println!("TEXT({})", raw.text().unwrap());
+                    consume_elem(&mut lens);
+                    reduce_depth(&mut lens);
+                },
+                Ok(Type::Array) => {
+                    let len = raw.array().unwrap();
+                    println!("ARRAY({:?}) {{", len);
+                    consume_elem(&mut lens);
+                    lens.push(len);
+                    if let cbor_event::Len::Len(0) = len {
+                        reduce_depth(&mut lens);
+                    }
+                },
+                Ok(Type::Map) => {
+                    let len = raw.map().unwrap();
+                    println!("MAP({:?}) {{", len);
+                    consume_elem(&mut lens);
+                    lens.push(match len {
+                        cbor_event::Len::Len(n) => cbor_event::Len::Len(2 * n),
+                        cbor_event::Len::Indefinite => cbor_event::Len::Indefinite,
+                    });
+                    if let cbor_event::Len::Len(0) = len {
+                        reduce_depth(&mut lens);
+                    }
+                },
                 Ok(Type::Tag) => println!("TAG({})", raw.tag().unwrap()),
-                Ok(Type::Special) => println!("SPECIAL({:?})", raw.special().unwrap()),
+                Ok(Type::Special) => {
+                    let special = raw.special().unwrap();
+                    println!("SPECIAL({:?})", special);
+                    if special == cbor_event::Special::Break {
+                        if let Some(cbor_event::Len::Indefinite) = lens.last() {
+                            lens.pop();
+                            reduce_depth(&mut lens);
+                        } else {
+                            panic!("unexpected break");
+                        }
+                    } else {
+                        consume_elem(&mut lens);
+                        reduce_depth(&mut lens);
+                    }
+                },
             }
         }
-        println!("}}");
     }
 
     fn deser_test<T: Deserialize + ToBytes + std::fmt::Debug>(orig: T) {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1156,8 +1156,8 @@ mod tests {
             CounterSignature::new_single(&s)
         };
         header_map.set_counter_signature(&counter_sig);
-        header_map.other_headers.insert(label_str("i am a string key"), Value::Text(String::from("also a string")));
-        header_map.other_headers.insert(label_int(-6), Value::Tag(3, Box::new(Value::Special(cbor_event::Special::Null))));
+        header_map.set_header(&label_str("i am a string key"), &CBORValue::new_text(String::from("also a string")));
+        header_map.set_header(&label_int(-6), &CBORValue::new_tagged(&TaggedCBOR::new(to_bignum(3u64), &CBORValue::new_special(&CBORSpecial::new_null()))));
         deser_test(header_map);
     }
 
@@ -1228,8 +1228,8 @@ mod tests {
         key_ops.add(&label_str("sadsddfd"));
         key_ops.add(&label_int(-100));
         cose_key.set_key_ops(&key_ops);
-        cose_key.other_headers.insert(label_str("dsfdsf"), Value::I64(-100));
-        cose_key.other_headers.insert(label_int(-50), Value::Text(String::from("134da2234fdsfd")));
+        cose_key.set_header(&label_str("dsfdsf"), &CBORValue::new_int(&Int::new_i32(-100)));
+        cose_key.set_header(&label_int(-50), &CBORValue::new_text(String::from("134da2234fdsfd")));
         deser_test(cose_key);
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -288,3 +288,28 @@ impl Deserialize for Int {
         })().map_err(|e| e.annotate("Int"))
     }
 }
+
+pub (crate) fn value_to_label(value: &CBORValue) -> Result<Label, JsError> {
+    match &value.0 {
+        CBORValueEnum::Int(x) => Ok(Label::new_int(x)),
+        CBORValueEnum::Text(x) => Ok(Label::new_text(x.clone())),
+        _ => Err(JsError::from_str(&format!("Invalid label: {:?}", value))),
+    }
+}
+pub (crate) fn value_to_bytes(value: &CBORValue) -> Result<Vec<u8>, JsError> {
+    match &value.0 {
+        CBORValueEnum::Bytes(bytes) => Ok(bytes.clone()),
+        _ => Err(JsError::from_str(&format!("Expected bytes, found: {:?}", value))),
+    }
+}
+
+pub (crate) fn label_to_value(label: &Label) -> CBORValue {
+    match &label.0 {
+        LabelEnum::Int(x) => CBORValue::new_int(x),
+        LabelEnum::Text(x) => CBORValue::new_text(x.to_string()),
+    }
+}
+
+pub (crate) fn labels_to_value(labels: &Labels) -> CBORValue {
+    CBORValue(CBORValueEnum::Array(labels.0.iter().map(label_to_value).collect::<Vec<_>>().into()))
+}


### PR DESCRIPTION
While the library had all the raw structs that represent the CDDL definitions included in COSE / CIP-08, how they are used was not very obvious or simple.

To help with this this PR introduces several builders/wrappers for interacting/building these structs.

Other utility functionality like CIP-08's user facing encoding were added as well.