### PR TITLE
Small variable name change because of JavaScript problems

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -398,10 +398,10 @@ impl Headers {
         self.unprotected.clone()
     }
 
-    pub fn new(protected: &ProtectedHeaderMap, unprotected: &HeaderMap) -> Self {
+    pub fn new(protected_: &ProtectedHeaderMap, unprotected_: &HeaderMap) -> Self {
         Self {
-            protected: protected.clone(),
-            unprotected: unprotected.clone(),
+            protected: protected_.clone(),
+            unprotected: unprotected_.clone(),
         }
     }
 }


### PR DESCRIPTION
I successfully compiled the rust library into an NPM package. But running it in JavaScript gives me an error:

```
static new(protected, unprotected) {
           ^^^^^^^^^

SyntaxError: Unexpected strict mode reserved word
```

Seems like `protected` is a reserved key word. So I added an underscore in the rust library and for consistency I added it to the unprotected argument as well.