### PR TITLE
Remove debug output in HeaderMap and COSEKey deserialization functions

### DIFF
--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -315,7 +315,6 @@ impl Deserialize for HeaderMap {
                 }
                 read += 1;
             }
-            println!("other_headers = {:?}", other_headers);
             Ok(Self {
                 algorithm_id,
                 criticality,
@@ -998,7 +997,6 @@ impl Deserialize for COSEKey {
                 }
                 read += 1;
             }
-            println!("other_headers = {:?}", other_headers);
             match key_type {
                 Some(kty) => Ok(Self {
                     key_type: kty,


### PR DESCRIPTION
There is a debug output left in deserialization functions, which complicates an integration of the library in applications sensible for stdout content (CLI tools for example)